### PR TITLE
Stop wsgiref.simple_server from logging to stderr by default.

### DIFF
--- a/.github/workflows/builder-publish.yaml
+++ b/.github/workflows/builder-publish.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2024.01.0
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-        uses: home-assistant/builder@2024.01.0
+        uses: home-assistant/builder@2024.03.5
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -31,6 +31,6 @@ jobs:
         uses: actions/checkout@v3.3.0
 
       - name: 🚀 Run Home Assistant Add-on Lint
-        uses: frenck/action-addon-linter@v2.11
+        uses: frenck/action-addon-linter@main
         with:
           path: "./${{ matrix.path }}"

--- a/awnet/CHANGELOG.md
+++ b/awnet/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.1] - 2024-03-30
+
+### Changed
+
+- Update logging format to include file name and line number for easier troubleshooting; update format for readability.
+- Update logger for WSGI to use the built-in Python logger.
+
 ## [1.1.0] - 2024-01-27
 
 ### Changed

--- a/awnet/CHANGELOG.md
+++ b/awnet/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Update logging format to include file name and line number for easier troubleshooting; update format for readability.
-- Update logger for WSGI to use the built-in Python logger.
+- Update logger for WSGI to use the built-in Python logger (and not log out to stderr, thanks @jruby411!).
 
 ## [1.1.0] - 2024-01-27
 

--- a/awnet/config.yaml
+++ b/awnet/config.yaml
@@ -1,5 +1,5 @@
 name: AWNET to HASS
-version: 1.1.0
+version: 1.1.1
 slug: awnet_to_hass
 description: Addon to capture local Ambient Weather data in Home Assistant
 arch:

--- a/awnet/rootfs/awnet.py
+++ b/awnet/rootfs/awnet.py
@@ -141,15 +141,16 @@ class AWNETWSGIRequestHandler(WSGIRequestHandler):
             self.raw_requestline = new_raw_requestline
             _LOGGER.debug("new raw_requestline: %s", self.raw_requestline)
         return super().parse_request()
-    # override defalt server logging
+
+    # Use the built-in log handler rather than outputting to stderr
     def log_message(self, format, *args):
-        pass
+        _LOGGER.info(format, *args)
 
 if __name__ == "__main__":
     from wsgiref.simple_server import make_server
 
     logging.basicConfig(stream = sys.stdout,
-                    format = '%(asctime)s %(levelname)8s : %(message)s',
+                    format = '[%(asctime)s] [%(levelname)-8s] %(message)s (%(filename)s:%(lineno)d)',
                     level = sys.argv[1])
 
     # probably shouldn't run on port 80 but that's what I specified in the ambient weather console

--- a/awnet/rootfs/awnet.py
+++ b/awnet/rootfs/awnet.py
@@ -141,6 +141,9 @@ class AWNETWSGIRequestHandler(WSGIRequestHandler):
             self.raw_requestline = new_raw_requestline
             _LOGGER.debug("new raw_requestline: %s", self.raw_requestline)
         return super().parse_request()
+    # override defalt server logging
+    def log_message(self, format, *args):
+        pass
 
 if __name__ == "__main__":
     from wsgiref.simple_server import make_server


### PR DESCRIPTION
I have my weather station set to send data to Home Assistant every 16 seconds. This was needlessly filling up the log with useless information and by-passing the python logging module.

The default wsgiref.simple_server sends every request to stderr, actually, not to python logging module. 

So, I followed the advice given here:

[Control wsgiref.simple_server log](https://stackoverflow.com/questions/31433682/control-wsgiref-simple-server-log)
